### PR TITLE
Hotfix replace Application::share with Application::singleton.

### DIFF
--- a/src/Snowfire/Mail/PostmarkServiceProvider.php
+++ b/src/Snowfire/Mail/PostmarkServiceProvider.php
@@ -34,7 +34,7 @@ class PostmarkServiceProvider extends \Illuminate\Mail\MailServiceProvider
     {
         $postmark = $this->app['config']->get('services.postmark', []);
 
-        $this->app['swift.mailer'] = $this->app->share(function ($app) use ($postmark) {
+        $this->app->singleton('swift.mailer', function ($app) use ($postmark) {
             return new Swift_Mailer(
                 new Swift_PostmarkTransport($postmark['api_key'])
             );


### PR DESCRIPTION
Use of \Illuminate\Foundation\Application::share method replaced with
\Illuminate\Foundation\Application::singleton since the former has been removed
as of Laravel 5.4.23. See laravel/framework@1a1969b.